### PR TITLE
[MRG] Switch from pep8 to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - echo "Scala style"
   - ./build/sbt scalastyle
   - echo "Python style"
-  - "flake8 --ignore=E402 sparklingml/"
+  - "flake8 --ignore=E402,F999,F403,F401 sparklingml/"
   - cd sparklingml
   - isort -c --skip lucene_analyzers.py
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - echo "Scala style"
   - ./build/sbt scalastyle
   - echo "Python style"
-  - "flake8 --ignore=E402,F999,F403,F401 sparklingml/"
+  - "flake8 --ignore=E305,E402,F401,F403,F405,F999 sparklingml/"
   - cd sparklingml
   - isort -c --skip lucene_analyzers.py
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ before_install:
   - source myenv/bin/activate
   - export PATH=myenv/bin/:$PATH
   - pip install spacy
-  - pip install nose codecov coverage pep8 pylint sphinx isort
+  - pip install nose codecov coverage flake8 pylint sphinx isort
   - pip install -r requirements.txt
   - python -m spacy download en
 script:
   - echo "Scala style"
   - ./build/sbt scalastyle
   - echo "Python style"
-  - "pep8 --ignore=E402 sparklingml/"
+  - "flake8 --ignore=E402 sparklingml/"
   - cd sparklingml
   - isort -c --skip lucene_analyzers.py
   - cd ..

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dev mailing list: https://groups.google.com/forum/#!forum/sparklingml-dev
 Sparkling ML consists of two components, a Python component and a Java/Scala component. The Python component depends on having the Java/Scala component pre-build which can be done by running `./build/sbt package`.
 
 
-The Python component depends on the package listed in requirements.txt (as well as part of setup.py). Development and testing also requires spacy, nose, codecov, pylint, and pep8.
+The Python component depends on the package listed in requirements.txt (as well as part of setup.py). Development and testing also requires spacy, nose, codecov, pylint, and flake8.
 
 
 The script `build_and_package.sh` builds & tests both the Scala and Python code.

--- a/build_and_package.sh
+++ b/build_and_package.sh
@@ -13,7 +13,7 @@ echo "Checking scala style issues"
 
 echo "Checking python style issues"
 
-pep8 --ignore=E402 sparklingml/
+flake8 --ignore=E402 sparklingml/
 
 echo "Building JVM code"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas>=0.13
 spacy
 future
 pyarrow==0.8.0
-pep8
+flake8
 nltk

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='holden@pigscanfly.ca',
     # Copy the shell script into somewhere likely to be in the users path
     packages=find_packages(),
-    include_package_data = True,
+    include_package_data=True,
     url='https://github.com/sparklingpandas/sparklingml',
     license='LICENSE',
     description='Add additional ML algorithms to Spark',
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         'pyspark>=2.3.0',
         'nltk',
-        'numpy', # Requires for PySpark ML
+        'numpy',  # Requires for PySpark ML
         'pandas',
         'spacy',
         'future',


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #43

#### What does this implement/fix? Explain your changes.
This PR introduces the necessary changes to switch from using the `pep8` package to the `flake8` package.  

#### Any other comments?
Instead of switching from `pep8` to `pycodestyles` as suggested initially. We agreed to switch to `flake8` which wraps pyflakes and pycodestyle:

- pypi: https://pypi.python.org/pypi/flake8
- doc: http://flake8.pycqa.org/en/latest/
