### PR TITLE
Accelerate Spacy Tokenize with Spark 2.3's new Apache Arrow powered UDFS

### DIFF
--- a/sparklingml/feature/python_pipelines.py
+++ b/sparklingml/feature/python_pipelines.py
@@ -125,7 +125,7 @@ class SpacyTokenizeTransformer(Model, HasInputCol, HasOutputCol):
         SpacyTokenize.setup(dataset._sc, dataset.sql_ctx, self.getLang())
         func = SpacyTokenize.func(self.getLang())
         ret_type = SpacyTokenize.returnType()
-        udf = UserDefinedFunction(func, ret_type)
+        udf = pandas_udf(func, ret_type)
         return dataset.withColumn(
             self.getOutputCol(), udf(self.getInputCol())
         )


### PR DESCRIPTION
Turns out we can return Arrays of primitive types as well.