### PR TITLE
[MRG] Download spacy en when needed

### DIFF
--- a/build_and_package.sh
+++ b/build_and_package.sh
@@ -5,7 +5,10 @@ set -e
 echo "Installing python requirements"
 
 pip install -r requirements.txt
-python -m spacy download en
+
+echo "Checking if spacy 'en' is installed otherwise download it"
+
+python -c "import spacy;spacy.load('en')" || python -m spacy download en
 
 echo "Checking scala style issues"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #42

#### What does this implement/fix? Explain your changes.
This PR  changes the ` sparklingml/build_and_package.sh` script to download the `spacy en` language only when it's not already installed. It does that by first trying to load it using `scapy.load('en')`. If that fails, It means (at least it's the default assumption) that `spacy en` needs to be installed.  

Concretely, this is the code that enhances the download strategy: 

`python -c "import spacy;spacy.load('en')" || python -m spacy download en`

#### Any other comments?
In case of a missing language, here's the output of the command 

```
$ python -c "import spacy;spacy.load('de')" || python -m spacy download de
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/spacy/__init__.py", line 19, in load
    return util.load_model(name, **overrides)
  File "/usr/local/lib/python2.7/dist-packages/spacy/util.py", line 120, in load_model
    raise IOError("Can't find model '%s'" % name)
IOError: Can't find model 'de'
Collecting https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.0.0/de_core_news_sm-2.0.0.tar.gz
  Downloading https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.0.0/de_core_news_sm-2.0.0.tar.gz (38.2MB)
    31% |██████████                      | 12.0MB 526kB/s eta 0:00:50
```

So seeing the following error in the output of `build_and_package.sh` is expected if `en` is not installed

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/spacy/__init__.py", line 19, in load
    return util.load_model(name, **overrides)
  File "/usr/local/lib/python2.7/dist-packages/spacy/util.py", line 120, in load_model
    raise IOError("Can't find model '%s'" % name)
IOError: Can't find model 'en'
```